### PR TITLE
Add "replace-me" check for md files

### DIFF
--- a/repolint-qcom.json
+++ b/repolint-qcom.json
@@ -1,44 +1,56 @@
 {
-    "extends": "https://raw.githubusercontent.com/qualcomm/.github/main/repolint.json",
-    "rules": {
-        "qualcomm-source-license-headers-exist": {
-            "level": "error",
-            "rule": {
-              "type": "file-starts-with",
-              "options": {
-                "globsAll": [
-                  "**/*.py",
-                  "**/*.js",
-                  "**/*.c",
-                  "**/*.cc",
-                  "**/*.cpp",
-                  "**/*.h",
-                  "**/*.ts",
-                  "**/*.sh",
-                  "**/*.rs",
-                  "**/*.java",
-                  "**/*.go",
-                  "**/*.bbclass",
-                  "**/*.S",
-                  "**/*.hpp"
-                ],
-                "skip-paths-matching": {
-                  "patterns": [
-                    "babel.config.js",
-                    "build\/",
-                    "jest.config.js",
-                    "node_modules\/",
-                    "types\/",
-                    "uthash.h"
-                  ]
-                },
-                "lineCount": 60,
-                "patterns": [
-                  "(Copyright|©).*Qualcomm Innovation Center, Inc|Qualcomm Technologies, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
-                ],
-                "flags": "i"
-              }
-            }
-          }        
+  "extends": "https://raw.githubusercontent.com/qualcomm/.github/main/repolint.json",
+  "rules": {
+    "qualcomm-source-license-headers-exist": {
+      "level": "error",
+      "rule": {
+        "type": "file-starts-with",
+        "options": {
+          "globsAll": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.c",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.h",
+            "**/*.ts",
+            "**/*.sh",
+            "**/*.rs",
+            "**/*.java",
+            "**/*.go",
+            "**/*.bbclass",
+            "**/*.S",
+            "**/*.hpp"
+          ],
+          "skip-paths-matching": {
+            "patterns": [
+              "babel.config.js",
+              "build\/",
+              "jest.config.js",
+              "node_modules\/",
+              "types\/",
+              "uthash.h"
+            ]
+          },
+          "lineCount": 60,
+          "patterns": [
+            "(Copyright|©).*Qualcomm Innovation Center, Inc|Qualcomm Technologies, Inc|Copyright (\\(c\\)|©) (20(1[2-9]|2[0-2])(-|,|\\s)*)+ The Linux Foundation"
+          ],
+          "flags": "i"
+        }
+      }
+    },
+    "replace-me-instances-from-repo-template": {
+      "level": "error",
+      "rule": {
+        "type": "file-not-contents",
+        "options": {
+          "globsAll": [
+            "**/*.md"
+          ],
+          "content": "REPLACE-ME"
+        }
+      }
     }
   }
+}

--- a/repolinter-test-data/fail-contains-replace-me.md
+++ b/repolinter-test-data/fail-contains-replace-me.md
@@ -1,0 +1,41 @@
+# Project Name
+
+*\<update with your project name and a short description\>*
+
+*\<search this repo for "REPLACE-ME" and update all instances accordingly\>*
+
+Project that does ... implemented in ... runs on Qualcomm® *\<processor\>*
+
+## Branches
+
+**main**: Primary development branch. Contributors should develop submissions based on this branch, and submit pull requests to this branch.
+
+## Requirements
+
+List requirements to run the project, how to install them, instructions to use docker container, etc...
+
+## Installation Instructions
+
+How to install the software itself.
+
+## Usage
+
+Describe how to use the project.
+
+## Development
+
+How to develop new features/fixes for the software. Maybe different than "usage". Also provide details on how to contribute via a [CONTRIBUTING.md file](CONTRIBUTING.md).
+
+## Getting in Contact
+
+How to contact maintainers. E.g. GitHub Issues, GitHub Discussions could be indicated for many cases. However a mail list or list of Maintainer e-mails could be shared for other types of discussions. E.g.
+
+* [Report an Issue on GitHub](../../issues)
+* [Open a Discussion on GitHub](../../discussions)
+* [E-mail us](mailto:REPLACE-ME@qti.qualcomm.com) for general questions
+
+## License
+
+*\<update with your project name and license\>*
+
+*\<REPLACE-ME\>* is licensed under the [BSD-3-clause License](https://spdx.org/licenses/BSD-3-Clause.html). See [LICENSE.txt](LICENSE.txt) for the full license text.


### PR DESCRIPTION
Our new repo template has a bunch of "REPLACE-ME"'s in the markdown files: https://github.com/qualcomm/qualcomm-repository-template. 

When onboarding new projects and the repolint-qcom is used, this will help us make sure no "replace me"s were forgotten.