### PR TITLE
Set qualcomm-source-license-headers-exist rule to warning

### DIFF
--- a/repolint-qcom.json
+++ b/repolint-qcom.json
@@ -2,7 +2,7 @@
   "extends": "https://raw.githubusercontent.com/qualcomm/.github/main/repolint.json",
   "rules": {
     "qualcomm-source-license-headers-exist": {
-      "level": "error",
+      "level": "warning",
       "rule": {
         "type": "file-starts-with",
         "options": {


### PR DESCRIPTION
Hi @mynameistechno 

Repolinter is failing `qualcomm-source-license-headers-exist` rule for `libminkadaptor/src/linux/tee.h` file in https://github.com/quic/minkipc. It seems we saw this issue in the past with https://github.com/quic/quic-teec and now we are throwing `warning` instead of `error` as per https://jira-dc.qualcomm.com/jira/browse/GITHUBQUIC-315. Should we apply the same to https://github.com/qualcomm/.github/blob/main/repolint-qcom.json#L5 rule and make it `warning`?

```
✖ qualcomm-source-license-headers-exist:
...
180  	✖ libminkadaptor/src/linux/tee.h: The first 200 lines do not contain the pattern(s): (Copyright|©).*Qualcomm Innovation Center, Inc|Qualcomm Technologies, Inc|Copyright (\(c\)|©) (20(1[2-9]|2[0-2])(-|,|\s)*)+ The Linux Foundation 
```
https://github.com/quic/minkipc/actions/runs/14674835147/job/41302767713#step:6:181

Relevant tickets:
https://jira-dc.qualcomm.com/jira/browse/OSSOPS-19417
https://jira-dc.qualcomm.com/jira/browse/GITHUBQUIC-315