### PR TITLE
Move PR email checker to templates

### DIFF
--- a/workflow-templates/pr-email-commit-checker.yml
+++ b/workflow-templates/pr-email-commit-checker.yml
@@ -1,4 +1,4 @@
-name: PR email addresses checker
+name: Qualcomm PR email addresses checker
 
 on: pull_request
 


### PR DESCRIPTION
It doesn't work well to require this workflow through a ruleset, so instead make it easy to install via a workflow template.