### PR TITLE
Updated README.md to point to SnapdragonGameStudios

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,7 +6,7 @@ Explore our organizations and repositories:
 
 * Learn about **AI Model Efficiency Toolkit (AIMET)** and other projects from Qualcomm Innovation Center, Inc.: [github.com/quic](https://github.com/quic)
 * **Qualcomm Linux**: [github.com/qualcomm-linux](https://github.com/qualcomm-linux)
-* **Snapdragon Studios**: [github.com/SnapdragonStudios](https://github.com/SnapdragonStudios)
+* **Snapdragon Game Studios**: [github.com/SnapdragonGameStudios](https://github.com/SnapdragonGameStudios)
 * **Audioreach™**, a complete end-to-end audio software solution: [github.com/audioreach](https://github.com/audioreach)
 * **Qualcomm® Robotics ROS**: [github.com/quic-qrb-ros](https://github.com/quic-qrb-ros) 
 * Explore our Systems on Chips, hardware and software development kits and tools at our website: [qualcomm.com/developer](https://qualcomm.com/developer)


### PR DESCRIPTION
SnapdragonStudios is now SnapdragonGameStudios (old github link is deprecated).